### PR TITLE
Add skillset and contact fields to discovery template

### DIFF
--- a/onboarding/03-discovery-session-guide.md
+++ b/onboarding/03-discovery-session-guide.md
@@ -82,6 +82,8 @@ Internally, we document:
 - Collaboration preferences and constraints
 - Current funding situation
 - Ecosystem connections
+- Skillset and expertise
+- Contact information
 - Safety or privacy considerations
 - Our initial thoughts on Foundry, Lab, or Studio fit
 - Recommended next steps
@@ -118,6 +120,15 @@ AOS participants: [Names]
 
 ### Ecosystem connections
 - [Relevant communities, cohorts, conferences, collaborators]
+
+### Skillset
+- [Technical skills, domain expertise, languages, frameworks]
+
+### Contact
+- Signal: [handle]
+- GitHub: [username]
+- Nostr: [nip-05 or npub]
+- Other: [any other contact methods]
 
 ### Safety/privacy notes
 - [Any relevant considerations]


### PR DESCRIPTION
## Summary
- Add Skillset section for tracking technical skills, domain expertise, languages, and frameworks
- Add Contact section with Signal, GitHub, Nostr, and other contact methods
- Update "What We Capture" list to reflect new fields

## Rationale
These additions help us:
- Better track contributor capabilities for Studio routing
- Maintain reliable contact information in one place
- Standardize how we capture skills across discovery sessions

## Test plan
- [x] Template renders correctly in markdown
- [x] New fields align with existing template structure